### PR TITLE
Add support for reporting GaugeCounter metrics

### DIFF
--- a/reporter/cloudwatch_test.go
+++ b/reporter/cloudwatch_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
+
 	metrics "github.com/launchdarkly/go-metrics"
 	"github.com/launchdarkly/go-metrics-cloudwatch/config"
 )
@@ -38,6 +39,40 @@ func TestCloudwatchReporter(t *testing.T) {
 	EmitMetrics(cfg)
 
 	if mock.metricsPut < 30 || mock.requests < 2 {
+		t.Fatal("No Metrics Put")
+	}
+}
+
+func TestCounters(t *testing.T) {
+	mock := &MockPutMetricsClient{}
+	registry := metrics.NewRegistry()
+	cfg := &config.Config{
+		Client:   mock,
+		Filter:   &config.NoFilter{},
+		Registry: registry,
+	}
+	counter := metrics.GetOrRegisterCounter(fmt.Sprintf("counter"), registry)
+	counter.Inc(1)
+	EmitMetrics(cfg)
+
+	if mock.metricsPut < 1 {
+		t.Fatal("No Metrics Put")
+	}
+}
+
+func TestGaugeCounters(t *testing.T) {
+	mock := &MockPutMetricsClient{}
+	registry := metrics.NewRegistry()
+	cfg := &config.Config{
+		Client:   mock,
+		Filter:   &config.NoFilter{},
+		Registry: registry,
+	}
+	gaugeCounter := metrics.GetOrRegisterGaugeCounter(fmt.Sprintf("gauge-counter"), registry)
+	gaugeCounter.Dec(1)
+	EmitMetrics(cfg)
+
+	if mock.metricsPut < 1 {
 		t.Fatal("No Metrics Put")
 	}
 }


### PR DESCRIPTION
Prior to this PR, the Cloudwatch reporter silently ignores `GaugeCounter` metrics (which we added to our fork of go-metrics in https://github.com/launchdarkly/go-metrics/pull/7).

This adds support, and includes them in the count of `counters` in the summary stats. (Not sure what the summary stats are intended for - LMK if I should count `gauge_counters` separately instead.)