### PR TITLE
Ensure we clear counts after each report

### DIFF
--- a/reporter/cloudwatch.go
+++ b/reporter/cloudwatch.go
@@ -75,7 +75,7 @@ func metricsData(cfg *config.Config) []*cloudwatch.MetricDatum {
 		switch metric := i.(type) {
 		case metrics.Counter:
 			counters += 1
-			count := float64(metric.Count())
+			count := float64(metric.Clear().Count())
 			if cfg.Filter.ShouldReport(name, count) {
 				datum := aDatum(name)
 				datum.Unit = aws.String(cloudwatch.StandardUnitCount)

--- a/reporter/cloudwatch.go
+++ b/reporter/cloudwatch.go
@@ -75,6 +75,8 @@ func metricsData(cfg *config.Config) []*cloudwatch.MetricDatum {
 		switch metric := i.(type) {
 		case metrics.Counter:
 			counters += 1
+			// For the LD flavor of go-metrics we do an atomic snapshot and clear
+			// Caveat: we cannot have multiple reports reading and clearing this metric
 			count := float64(metric.Clear().Count())
 			if cfg.Filter.ShouldReport(name, count) {
 				datum := aDatum(name)
@@ -97,9 +99,8 @@ func metricsData(cfg *config.Config) []*cloudwatch.MetricDatum {
 				data = append(data, datum)
 				countersOut += 1
 			}
-			if cfg.ResetCountersOnReport {
-				metric.Dec(metric.Count()) // GaugeCounter doesn't have Clear()
-			}
+			// We don't clear gauge counters on ResetCountersOnReport because they cannot recover their value like normal gauges
+			// They can only increment and decrement and so cannot be cleared after they are created.
 		case metrics.Gauge:
 			gagues += 1
 			value := float64(metric.Value())

--- a/reporter/cloudwatch_test.go
+++ b/reporter/cloudwatch_test.go
@@ -54,6 +54,9 @@ func TestCounters(t *testing.T) {
 	counter := metrics.GetOrRegisterCounter(fmt.Sprintf("counter"), registry)
 	counter.Inc(1)
 	EmitMetrics(cfg)
+	if counter.Count() != 0 {
+		t.Fatalf("expected counter to be cleared but got %d", counter.Count())
+	}
 
 	if mock.metricsPut < 1 {
 		t.Fatal("No Metrics Put")


### PR DESCRIPTION
The version of go-metrics we use (our own) requires counters to be cleared after they are captured.  This makes that change.  This fixes counter reporting for experimentation processor.
