### PR TITLE
[ch58126] Fix reporting for timers and make names match our graphite reporter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,13 +4,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
+
 	"github.com/launchdarkly/go-metrics"
 )
 
 const (
 	Perc50  = float64(0.50)
-	Perc75  = float64(0.50)
-	Perc95  = float64(0.50)
+	Perc75  = float64(0.75)
+	Perc95  = float64(0.95)
 	Perc99  = float64(0.99)
 	Perc999 = float64(0.999)
 	Perc100 = float64(1)

--- a/config/config.go
+++ b/config/config.go
@@ -22,13 +22,13 @@ type PutMetricsClient interface {
 }
 
 type Config struct {
-	Filter                Filter
-	Client                PutMetricsClient
-	ReportingInterval     time.Duration
-	Registry              metrics.Registry
-	Namespace             string
-	StaticDimensions      map[string]string
-	ResetCountersOnReport bool
+	Filter            Filter
+	Client            PutMetricsClient
+	ReportingInterval time.Duration
+	Registry          metrics.Registry
+	Namespace         string
+	StaticDimensions  map[string]string
+	DurationUnit      time.Duration
 }
 
 type Filter interface {

--- a/reporter/cloudwatch.go
+++ b/reporter/cloudwatch.go
@@ -3,6 +3,8 @@ package reporter
 import (
 	"fmt"
 	"log"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -57,8 +59,8 @@ func putMetrics(cfg *config.Config, data []*cloudwatch.MetricDatum) error {
 }
 
 func metricsData(cfg *config.Config) []*cloudwatch.MetricDatum {
-	counters, gagues, histos, meters, timers := 0, 0, 0, 0, 0
-	countersOut, gaguesOut, histosOut, metersOut, timersOut := 0, 0, 0, 0, 0
+	counters, gauges, histos, meters, timers := 0, 0, 0, 0, 0
+	countersOut, gaugesOut, histosOut, metersOut, timersOut := 0, 0, 0, 0, 0
 
 	data := []*cloudwatch.MetricDatum{}
 	timestamp := aws.Time(time.Now())
@@ -102,53 +104,64 @@ func metricsData(cfg *config.Config) []*cloudwatch.MetricDatum {
 			// We don't clear gauge counters on ResetCountersOnReport because they cannot recover their value like normal gauges
 			// They can only increment and decrement and so cannot be cleared after they are created.
 		case metrics.Gauge:
-			gagues += 1
+			gauges += 1
 			value := float64(metric.Value())
 			if cfg.Filter.ShouldReport(name, value) {
 				datum := aDatum(name)
 				datum.Unit = aws.String(cloudwatch.StandardUnitCount)
 				datum.Value = aws.Float64(float64(value))
 				data = append(data, datum)
-				gaguesOut += 1
+				gaugesOut += 1
 			}
 		case metrics.GaugeFloat64:
-			gagues += 1
+			gauges += 1
 			value := float64(metric.Value())
 			if cfg.Filter.ShouldReport(name, value) {
 				datum := aDatum(name)
 				datum.Unit = aws.String(cloudwatch.StandardUnitCount)
 				datum.Value = aws.Float64(value)
 				data = append(data, datum)
-				gaguesOut += 1
+				gaugesOut += 1
 			}
 		case metrics.Histogram:
 			histos += 1
 			h := metric.Clear() // For the LD flavor of go-metrics we do an atomic snapshot and clear
-			value := float64(h.Count())
-			if cfg.Filter.ShouldReport(name, value) {
-				for _, p := range cfg.Filter.Percentiles(name) {
-					pname := fmt.Sprintf("%s-perc%.3f", name, p)
-					pvalue := h.Percentile(p)
-					if cfg.Filter.ShouldReport(pname, pvalue) {
-						datum := aDatum(pname)
-						datum.Unit = aws.String(cloudwatch.StandardUnitCount)
-						datum.Value = aws.Float64(pvalue)
-						data = append(data, datum)
-						histosOut += 1
-					}
+
+			for n, v := range map[string]float64{
+				fmt.Sprintf("%s.count", name):   float64(h.Count()),
+				fmt.Sprintf("%s.min", name):     float64(h.Min()),
+				fmt.Sprintf("%s.max", name):     float64(h.Max()),
+				fmt.Sprintf("%s.mean", name):    h.Mean(),
+				fmt.Sprintf("%s.std-dev", name): h.StdDev(),
+			} {
+				if cfg.Filter.ShouldReport(n, v) {
+					datum := aDatum(n)
+					datum.Value = aws.Float64(v)
+					data = append(data, datum)
+					histosOut += 1
+				}
+			}
+			for _, p := range cfg.Filter.Percentiles(name) {
+				percentileLabel := strings.Replace(strconv.FormatFloat(p*100.0, 'f', -1, 64), ".", "", 1)
+				pname := fmt.Sprintf("%s.%s-percentile", name, percentileLabel)
+				pvalue := h.Percentile(p)
+				if cfg.Filter.ShouldReport(pname, pvalue) {
+					datum := aDatum(pname)
+					datum.Value = aws.Float64(pvalue)
+					data = append(data, datum)
+					histosOut += 1
 				}
 			}
 		case metrics.Meter:
 			meters += 1
 			m := metric.Snapshot()
-			dataz := map[string]float64{
+			for n, v := range map[string]float64{
 				fmt.Sprintf("%s.count", name):          float64(m.Count()),
 				fmt.Sprintf("%s.one-minute", name):     m.Rate1(),
 				fmt.Sprintf("%s.five-minute", name):    m.Rate5(),
 				fmt.Sprintf("%s.fifteen-minute", name): m.Rate15(),
 				fmt.Sprintf("%s.mean", name):           m.RateMean(),
-			}
-			for n, v := range dataz {
+			} {
 				if cfg.Filter.ShouldReport(n, v) {
 					datum := aDatum(n)
 					datum.Value = aws.Float64(v)
@@ -162,14 +175,14 @@ func metricsData(cfg *config.Config) []*cloudwatch.MetricDatum {
 			if t.Count() == 0 {
 				return
 			}
-			dataz := map[string]float64{
-				fmt.Sprintf("%s.count", name):          float64(t.Count()),
-				fmt.Sprintf("%s.one-minute", name):     t.Rate1(),
-				fmt.Sprintf("%s.five-minute", name):    t.Rate5(),
-				fmt.Sprintf("%s.fifteen-minute", name): t.Rate15(),
-				fmt.Sprintf("%s.mean", name):           t.RateMean(),
-			}
-			for n, v := range dataz {
+
+			for n, v := range map[string]float64{
+				fmt.Sprintf("%s.count", name):   float64(t.Count()),
+				fmt.Sprintf("%s.min", name):     float64(t.Min()),
+				fmt.Sprintf("%s.max", name):     float64(t.Max()),
+				fmt.Sprintf("%s.mean", name):    t.Mean(),
+				fmt.Sprintf("%s.std-dev", name): t.StdDev(),
+			} {
 				if cfg.Filter.ShouldReport(n, v) {
 					datum := aDatum(n)
 					datum.Value = aws.Float64(v)
@@ -178,7 +191,8 @@ func metricsData(cfg *config.Config) []*cloudwatch.MetricDatum {
 				}
 			}
 			for _, p := range cfg.Filter.Percentiles(name) {
-				pname := fmt.Sprintf("%s-perc%.3f", name, p)
+				percentileLabel := strings.Replace(strconv.FormatFloat(p*100.0, 'f', -1, 64), ".", "", 1)
+				pname := fmt.Sprintf("%s.%s-percentile", name, percentileLabel)
 				pvalue := t.Percentile(p)
 				if cfg.Filter.ShouldReport(pname, pvalue) {
 					datum := aDatum(pname)
@@ -187,14 +201,13 @@ func metricsData(cfg *config.Config) []*cloudwatch.MetricDatum {
 					timersOut += 1
 				}
 			}
-
 		}
 	})
-	total := counters + gagues + histos + meters + timers
-	totalOut := countersOut + gaguesOut + histosOut + metersOut + timersOut
+	total := counters + gauges + histos + meters + timers
+	totalOut := countersOut + gaugesOut + histosOut + metersOut + timersOut
 	if !Silence {
-		log.Printf("component=cloudwatch-reporter fn=metricsData at=sources total=%d counters=%d gagues=%d histos=%d meters=%d timers=%d", total, counters, gagues, histos, meters, timers)
-		log.Printf("component=cloudwatch-reporter fn=metricsData at=targets total=%d counters=%d gagues=%d histos=%d meters=%d timers=%d", totalOut, countersOut, gaguesOut, histosOut, metersOut, timersOut)
+		log.Printf("component=cloudwatch-reporter fn=metricsData at=sources total=%d counters=%d gauges=%d histos=%d meters=%d timers=%d", total, counters, gauges, histos, meters, timers)
+		log.Printf("component=cloudwatch-reporter fn=metricsData at=targets total=%d counters=%d gauges=%d histos=%d meters=%d timers=%d", totalOut, countersOut, gaugesOut, histosOut, metersOut, timersOut)
 	}
 
 	return data

--- a/reporter/cloudwatch_test.go
+++ b/reporter/cloudwatch_test.go
@@ -26,9 +26,10 @@ func TestCloudwatchReporter(t *testing.T) {
 	mock := &MockPutMetricsClient{}
 	registry := metrics.NewRegistry()
 	cfg := &config.Config{
-		Client:   mock,
-		Filter:   &config.NoFilter{},
-		Registry: registry,
+		Client:       mock,
+		Filter:       &config.NoFilter{},
+		Registry:     registry,
+		DurationUnit: time.Millisecond,
 	}
 
 	for i := 0; i < 30; i++ {
@@ -47,9 +48,10 @@ func TestCounters(t *testing.T) {
 	mock := &MockPutMetricsClient{}
 	registry := metrics.NewRegistry()
 	cfg := &config.Config{
-		Client:   mock,
-		Filter:   &config.NoFilter{},
-		Registry: registry,
+		Client:       mock,
+		Filter:       &config.NoFilter{},
+		Registry:     registry,
+		DurationUnit: time.Millisecond,
 	}
 	counter := metrics.GetOrRegisterCounter(fmt.Sprintf("counter"), registry)
 	counter.Inc(1)
@@ -67,9 +69,10 @@ func TestGaugeCounters(t *testing.T) {
 	mock := &MockPutMetricsClient{}
 	registry := metrics.NewRegistry()
 	cfg := &config.Config{
-		Client:   mock,
-		Filter:   &config.NoFilter{},
-		Registry: registry,
+		Client:       mock,
+		Filter:       &config.NoFilter{},
+		Registry:     registry,
+		DurationUnit: time.Millisecond,
 	}
 	gaugeCounter := metrics.GetOrRegisterGaugeCounter(fmt.Sprintf("gauge-counter"), registry)
 	gaugeCounter.Dec(1)
@@ -85,9 +88,10 @@ func TestHistograms(t *testing.T) {
 	registry := metrics.NewRegistry()
 	filter := &config.NoFilter{}
 	cfg := &config.Config{
-		Client:   mock,
-		Filter:   filter,
-		Registry: registry,
+		Client:       mock,
+		Filter:       filter,
+		Registry:     registry,
+		DurationUnit: time.Millisecond,
 	}
 
 	hist := metrics.GetOrRegisterHistogram(fmt.Sprintf("histo"), registry, metrics.NewUniformSample(1024))
@@ -104,9 +108,10 @@ func TestTimers(t *testing.T) {
 	mock := &MockPutMetricsClient{}
 	registry := metrics.NewRegistry()
 	cfg := &config.Config{
-		Client:   mock,
-		Filter:   &config.NoFilter{},
-		Registry: registry,
+		Client:       mock,
+		Filter:       &config.NoFilter{},
+		Registry:     registry,
+		DurationUnit: time.Millisecond,
 	}
 	timer := metrics.GetOrRegisterTimer(fmt.Sprintf("timer"), registry)
 	timer.Update(10 * time.Second)
@@ -121,9 +126,10 @@ func TestFilters(t *testing.T) {
 	mock := &MockPutMetricsClient{}
 	registry := metrics.NewRegistry()
 	cfg := &config.Config{
-		Client:   mock,
-		Filter:   &config.AllFilter{},
-		Registry: registry,
+		Client:       mock,
+		Filter:       &config.AllFilter{},
+		Registry:     registry,
+		DurationUnit: time.Millisecond,
 	}
 
 	timer := metrics.GetOrRegisterTimer(fmt.Sprintf("timer"), registry)


### PR DESCRIPTION
The code for reporting timer values was blatantly copied from the code for reporting meters, but we need the more histogram-related metrics. We'll be losing the rate metrics, but we don't seem to use those and our graphite reporter has never reported them, so I'm not sure we need to keep them.